### PR TITLE
Add .env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_HOST=127.0.0.1
+DB_NAME=database_name
+DB_USER=username
+DB_PASS=password

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# PowerLevel
+
+## Setup
+
+1. Copy `.env.example` to `.env`.
+2. Edit `.env` and replace the placeholder values with your database credentials.
+
+The application will read these values to connect to the database.

--- a/config/database.php
+++ b/config/database.php
@@ -1,8 +1,14 @@
 <?php
-define('DB_HOST', '127.0.0.1:3306');
-define('DB_NAME', 'u629142522_PowerLevel');
-define('DB_USER', 'u629142522_K3NII0');
-define('DB_PASS', '@78Aee4afdc6');
+$envPath = __DIR__ . '/../.env';
+$env = [];
+if (file_exists($envPath)) {
+    $env = parse_ini_file($envPath);
+}
+
+define('DB_HOST', $env['DB_HOST'] ?? getenv('DB_HOST') ?? '127.0.0.1');
+define('DB_NAME', $env['DB_NAME'] ?? getenv('DB_NAME') ?? 'database');
+define('DB_USER', $env['DB_USER'] ?? getenv('DB_USER') ?? 'user');
+define('DB_PASS', $env['DB_PASS'] ?? getenv('DB_PASS') ?? 'password');
 
 try {
     $pdo = new PDO(

--- a/includes/config.php
+++ b/includes/config.php
@@ -1,8 +1,14 @@
 <?php
-$host = 'localhost';
-$db   = 'u629142522_PowerLevel';
-$user = 'u629142522_K3NII0';     // à remplacer par ton user Hostinger
-$pass = '@78Aee4afdc6';    // à remplacer par ton mot de passe
+$envPath = __DIR__ . '/../.env';
+$env = [];
+if (file_exists($envPath)) {
+    $env = parse_ini_file($envPath);
+}
+
+$host = $env['DB_HOST'] ?? getenv('DB_HOST') ?? 'localhost';
+$db   = $env['DB_NAME'] ?? getenv('DB_NAME') ?? 'database';
+$user = $env['DB_USER'] ?? getenv('DB_USER') ?? 'user';
+$pass = $env['DB_PASS'] ?? getenv('DB_PASS') ?? 'password';
 $charset = 'utf8mb4';
 
 $dsn = "mysql:host=$host;dbname=$db;charset=$charset";


### PR DESCRIPTION
## Summary
- load DB settings from `.env` in `includes/config.php`
- support optional `.env` in `config/database.php`
- add `.env.example` for DB credentials
- document setup instructions in `README.md`

## Testing
- `php -v` *(fails: command not found)*