### PR TITLE
Add CSRF tokens for resets and admin deletes

### DIFF
--- a/dashboard_parts/user_info.php
+++ b/dashboard_parts/user_info.php
@@ -1,4 +1,5 @@
 <?php
+require_once 'includes/csrf.php';
 // Récup ornement prestige
 $stmt = $pdo->prepare("SELECT icon_url FROM prestige_styles WHERE code = ?");
 $stmt->execute([$user['prestige']]);
@@ -89,13 +90,17 @@ $publicUrl = $token ? $baseUrl . $token : '';
                     <div class="h-2 bg-purple-500 rounded" style="width: <?= ($_SESSION['level'] / 50) * 100 ?>%;"></div>
                 </div>
                 <div class="pt-4">
-                <a href="user_reset_stats.php?action=reset" onclick="return confirm('Réinitialiser toutes tes stats ?');" class="group relative px-3 p-2 text-sm/6 text-sky-800 dark:text-sky-300">
-    <span class="absolute inset-0 border border-dashed border-sky-300/60 bg-sky-400/10 group-hover:bg-sky-400/15 dark:border-sky-300/30">       
+                <form action="user_reset_stats.php" method="POST" onsubmit="return confirm('Réinitialiser toutes tes stats ?');" class="inline">
+                    <input type="hidden" name="action" value="reset">
+                    <input type="hidden" name="csrf_token" value="<?= get_csrf_token() ?>">
+                    <button type="submit" class="group relative px-3 p-2 text-sm/6 text-sky-800 dark:text-sky-300">
+    <span class="absolute inset-0 border border-dashed border-sky-300/60 bg-sky-400/10 group-hover:bg-sky-400/15 dark:border-sky-300/30">
     </span>Réinitialiser mes stats<svg width="5" height="5" viewBox="0 0 5 5" class="absolute top-[-2px] left-[-2px] fill-sky-300 dark:fill-sky-300/50">
         <path d="M2 0h1v2h2v1h-2v2h-1v-2h-2v-1h2z"></path></svg><svg width="5" height="5" viewBox="0 0 5 5" class="absolute top-[-2px] right-[-2px] fill-sky-300 dark:fill-sky-300/50">
             <path d="M2 0h1v2h2v1h-2v2h-1v-2h-2v-1h2z"></path></svg><svg width="5" height="5" viewBox="0 0 5 5" class="absolute bottom-[-2px] left-[-2px] fill-sky-300 dark:fill-sky-300/50">
                 <path d="M2 0h1v2h2v1h-2v2h-1v-2h-2v-1h2z"></path></svg><svg width="5" height="5" viewBox="0 0 5 5" class="absolute right-[-2px] bottom-[-2px] fill-sky-300 dark:fill-sky-300/50">
-                    <path d="M2 0h1v2h2v1h-2v2h-1v-2h-2v-1h2z"></path></svg></a>
+                    <path d="M2 0h1v2h2v1h-2v2h-1v-2h-2v-1h2z"></path></svg></button>
+                </form>
         </div>
             </div>
         </div>

--- a/includes/csrf.php
+++ b/includes/csrf.php
@@ -1,0 +1,11 @@
+<?php
+function get_csrf_token(): string {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function check_csrf_token(string $token): bool {
+    return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
+}

--- a/user_reset_stats.php
+++ b/user_reset_stats.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 require_once 'includes/config.php';
+require_once 'includes/csrf.php';
 
 if (!isset($_SESSION['user_id'])) {
     header('Location: login.php');
@@ -9,9 +10,8 @@ if (!isset($_SESSION['user_id'])) {
 
 $user_id = $_SESSION['user_id'];
 
-// Si action GET pour debug rapide (depuis lien)
-if (isset($_GET['action'])) {
-    $action = $_GET['action'];
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && isset($_POST['csrf_token']) && check_csrf_token($_POST['csrf_token'])) {
+    $action = $_POST['action'];
 
     if ($action === 'reset') {
         $pdo->prepare("DELETE FROM user_workouts WHERE user_id = ?")->execute([$user_id]);


### PR DESCRIPTION
## Summary
- create reusable CSRF helpers
- secure user stat reset through POST/CSRF
- convert reset link to form with token
- protect admin deletions in badges, users and workouts using POST + CSRF

## Testing
- `php --version` *(fails: command not found)*