### PR TITLE
Implement CSRF protection

### DIFF
--- a/admin/badges.php
+++ b/admin/badges.php
@@ -1,8 +1,10 @@
 <?php
 require_once 'includes/auth.php';
 require_once '../includes/config.php';
+require_once "../includes/security.php"; $csrf_token = generateCsrfToken();
 
 // Ajouter un badge
+    if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) { die("Invalid CSRF"); }
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $name = trim($_POST['name']);
     $description = trim($_POST['description']);
@@ -56,6 +58,7 @@ $badges = $pdo->query("SELECT * FROM badges ORDER BY level_required")->fetchAll(
 
             <form method="POST" class="space-y-4">
                 <div>
+                <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
                     <label class="block text-sm text-gray-300">Nom :</label>
                     <input type="text" name="name" required
                            class="w-full bg-gray-700 text-white px-4 py-2 rounded border border-gray-600">

--- a/admin/edit_user.php
+++ b/admin/edit_user.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'includes/auth.php';
 require_once '../includes/config.php';
+require_once "../includes/security.php"; $csrf_token = generateCsrfToken();
 
 if (!isset($_GET['id'])) {
     header('Location: users.php');
@@ -10,6 +11,7 @@ if (!isset($_GET['id'])) {
 $user_id = (int) $_GET['id'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) { die("Invalid CSRF"); }
     $username = trim($_POST['username']);
     $email = trim($_POST['email']);
     $level = (int) $_POST['level'];
@@ -51,6 +53,7 @@ $profiles = ['débutant', 'amateur'];
         <div class="bg-gray-800 border border-purple-600 p-6 rounded-xl shadow-md">
             <form method="POST" class="space-y-4">
                 <div>
+                <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
                     <label class="block text-sm text-gray-300">Pseudo :</label>
                     <input type="text" name="username" value="<?= htmlspecialchars($user['username']) ?>" required
                            class="w-full bg-gray-700 text-white px-4 py-2 rounded border border-gray-600">

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,3 +1,8 @@
+<?php
+session_start();
+require_once "../includes/security.php";
+$csrf_token = generateCsrfToken();
+?>
 <!DOCTYPE html>
 <html lang="fr">
 <head>
@@ -13,6 +18,7 @@
 
         <form action="process_login.php" method="POST" class="space-y-4 text-left">
             <div>
+                <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
                 <label class="block text-sm text-gray-300">Nom d'utilisateur :</label>
                 <input type="text" name="username" required
                        class="w-full bg-gray-700 text-white px-4 py-2 rounded border border-gray-600">

--- a/admin/penalties.php
+++ b/admin/penalties.php
@@ -1,8 +1,10 @@
 <?php
 require_once 'includes/auth.php';
 require_once '../includes/config.php';
+require_once "../includes/security.php"; $csrf_token = generateCsrfToken();
 
 // Ajouter une pénalité
+    if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) { die("Invalid CSRF"); }
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $user_id = $_POST['user_id'];
     $reason = trim($_POST['reason']);
@@ -42,6 +44,7 @@ $history = $pdo->query("
             <h2 class="text-xl font-semibold text-red-300 mb-4">➕ Appliquer une pénalité</h2>
             <form method="POST" class="space-y-4">
                 <div>
+                <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
                     <label class="block text-sm text-gray-300 mb-1">Utilisateur :</label>
                     <select name="user_id" required class="w-full bg-gray-700 border border-gray-600 text-white rounded px-4 py-2">
                         <?php foreach ($users as $user): ?>

--- a/admin/prestige.php
+++ b/admin/prestige.php
@@ -1,8 +1,10 @@
 <?php
 require_once 'includes/auth.php';
 require_once '../includes/config.php';
+require_once "../includes/security.php"; $csrf_token = generateCsrfToken();
 
 // 🔄 Mise à jour icône d’un prestige
+    if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) { die("Invalid CSRF"); }
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $code = $_POST['code'];
     $icon = trim($_POST['icon_url']);
@@ -48,6 +50,7 @@ $prestiges = $pdo->query("SELECT * FROM prestige_styles ORDER BY FIELD(code, 'E'
 
                 <form method="POST" class="space-y-2">
                     <input type="hidden" name="code" value="<?= $prestige['code'] ?>">
+                    <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
                     <input type="url" name="icon_url" value="<?= htmlspecialchars($prestige['icon_url']) ?>"
                            placeholder="URL de l’image"
                            class="w-full px-4 py-2 bg-gray-700 text-white border border-gray-600 rounded">

--- a/admin/process_login.php
+++ b/admin/process_login.php
@@ -1,8 +1,10 @@
 <?php
 session_start();
 require_once '../includes/config.php';
+require_once "../includes/security.php";
 
 if (!isset($_POST['username'], $_POST['password'])) {
+if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) { die("Invalid CSRF token"); }
     die('Champs manquants.');
 }
 

--- a/admin/update_training.php
+++ b/admin/update_training.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'includes/auth.php';
 require_once '../includes/config.php';
+require_once "../includes/security.php"; $csrf_token = generateCsrfToken();
 
 if (!isset($_GET['id'])) {
     header('Location: workouts.php');
@@ -25,6 +26,7 @@ $exercises = $stmt->fetchAll();
 
 // Modifier le bloc
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) { die("Invalid CSRF"); }
     $level_min = $_POST['level_min'];
     $level_max = $_POST['level_max'];
     $duration = $_POST['duration_minutes'];
@@ -65,6 +67,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     <form method="POST" class="space-y-4 bg-gray-800 p-6 rounded-xl border border-purple-600">
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
             <div>
                 <label class="block text-sm text-gray-300">Prestige :</label>
                 <select name="prestige_required" class="w-full bg-gray-700 text-white px-3 py-2 rounded border border-gray-600">

--- a/admin/workouts.php
+++ b/admin/workouts.php
@@ -1,9 +1,11 @@
 <?php
 require_once 'includes/auth.php';
 require_once '../includes/config.php';
+require_once "../includes/security.php"; $csrf_token = generateCsrfToken();
 
 // Ajouter un bloc
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) { die("Invalid CSRF"); }
     $level_min = $_POST['level_min'];
     $level_max = $_POST['level_max'];
     $duration = $_POST['duration_minutes'];
@@ -61,6 +63,7 @@ function getExercises($pdo, $block_id) {
             <h2 class="text-xl font-semibold mb-4 text-purple-300">➕ Nouveau bloc</h2>
             <form method="POST" class="space-y-4">
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
                 <div class="space-y-3">
     <div>
         <label class="block text-sm text-gray-300 mb-1">Prestige :</label>

--- a/dashboard_logic.php
+++ b/dashboard_logic.php
@@ -1,6 +1,7 @@
 <?php
 
 if (session_status() === PHP_SESSION_NONE) session_start();
+require_once "includes/security.php";
 require_once 'includes/config.php';
 
 
@@ -43,6 +44,7 @@ foreach ($new_badges as $badge) {
 $show_class_choice = ($level >= 10 && $user['profile_type'] === 'débutant' && !isset($_GET['class_decided']));
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['class_choice'])) {
+    if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) { exit; }
     $choice = $_POST['class_choice'];
     if ($choice === 'amateur') {
         $pdo->prepare("UPDATE users SET profile_type = 'amateur' WHERE id = ?")->execute([$user_id]);
@@ -69,6 +71,7 @@ $show_prestige_modal = (
 );
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['prestige_choice'])) {
+    if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) { exit; }
     $choice = $_POST['prestige_choice'];
     if ($choice === 'prestige' && $next_prestige) {
         $stmt = $pdo->prepare("UPDATE users SET prestige = ?, level = 1, experience = 0, last_prestige_offer = NOW() WHERE id = ?");

--- a/dashboard_parts/class_modal.php
+++ b/dashboard_parts/class_modal.php
@@ -1,3 +1,7 @@
+<?php
+require_once "includes/security.php";
+$csrf_token = generateCsrfToken();
+?>
 <?php if ($show_class_choice): ?>
     <div id="modalOverlay" style="position: fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.6); display:flex; align-items:center; justify-content:center; z-index:1000;">
         <div style="background:#fff; padding:30px; border-radius:10px; max-width:500px; text-align:center;">
@@ -5,6 +9,7 @@
             <p>Tu es arrivé au niveau 10 ! Que souhaites-tu faire ?</p>
 
             <form method="POST">
+                <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
                 <button name="class_choice" value="amateur" style="margin:10px; padding:10px;">🚀 Passer en Amateur (conserver progression)</button>
                 <button name="class_choice" value="reset" style="margin:10px; padding:10px;">🔄 Rester Débutant (reset et rejouer)</button>
             </form>

--- a/dashboard_parts/prestige_modal.php
+++ b/dashboard_parts/prestige_modal.php
@@ -1,3 +1,7 @@
+<?php
+require_once "includes/security.php";
+$csrf_token = generateCsrfToken();
+?>
 <?php if ($show_prestige_modal): ?>
     <div id="modalOverlay" style="position: fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.6); display:flex; align-items:center; justify-content:center; z-index:1000;">
         <div style="background:#fff; padding:30px; border-radius:10px; max-width:500px; text-align:center;">
@@ -7,6 +11,7 @@
             <p><em>(Tu conserveras ton profil, mais ton niveau et ton XP seront remis à zéro)</em></p>
 
             <form method="POST">
+                <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
                 <button name="prestige_choice" value="prestige" style="margin:10px; padding:10px;">🔱 Passer Prestige <?= $next_prestige ?></button>
                 <button name="prestige_choice" value="stay" style="margin:10px; padding:10px;">♻️ Rester en Prestige <?= $current_prestige ?></button>
             </form>

--- a/dashboard_parts/rest_days.php
+++ b/dashboard_parts/rest_days.php
@@ -1,10 +1,11 @@
 <?php
 if (!isset($user_id)) {
     session_start();
-    $user_id = $_SESSION['user_id'];
-    require_once 'includes/config.php';
+    $user_id = $_SESSION["user_id"];
+    require_once "includes/config.php";
 }
-
+require_once "includes/security.php";
+$csrf_token = generateCsrfToken();
 $jours = ['lundi','mardi','mercredi','jeudi','vendredi','samedi','dimanche'];
 
 // Mise à jour des jours de repos
@@ -67,6 +68,7 @@ $rest = $stmt->fetch();
 </div>
 
 <script>
+const csrfToken = "<?= $csrf_token ?>";
 document.addEventListener('DOMContentLoaded', () => {
     const checkboxes = document.querySelectorAll('input[type="checkbox"][name="jours[]"]');
     const message = document.getElementById('restDaysMessage');
@@ -95,7 +97,7 @@ document.addEventListener('DOMContentLoaded', () => {
             fetch('dashboard_parts/update_rest_days.php', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-                body: `rest_day_1=${encodeURIComponent(selected[0])}&rest_day_2=${encodeURIComponent(selected[1])}`
+                body: `rest_day_1=${encodeURIComponent(selected[0])}&rest_day_2=${encodeURIComponent(selected[1])}&csrf_token=${encodeURIComponent(csrfToken)}`
             }).then(() => {
                 fetch('dashboard_parts/get_rest_days.php')
                     .then(res => res.text())

--- a/dashboard_parts/toggle_public.php
+++ b/dashboard_parts/toggle_public.php
@@ -1,8 +1,10 @@
 <?php
 session_start();
 require_once '../includes/config.php';
+require_once "../includes/security.php";
 
 $user_id = $_SESSION['user_id'] ?? null;
+if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) exit;
 if (!$user_id || !isset($_POST['action'])) exit;
 
 if ($_POST['action'] === 'public') {

--- a/dashboard_parts/training_process.php
+++ b/dashboard_parts/training_process.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 require_once '../includes/config.php';
+require_once "../includes/security.php";
 
 if (!isset($_SESSION['user_id'])) {
     header("Location: login.php");
@@ -30,6 +31,7 @@ $jour_de_repos = (
 );
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) { header("Location: ../dashboard.php"); exit; }
 // Vérif du token pour éviter soumission multiple
 if (
     !isset($_POST['training_token']) ||

--- a/dashboard_parts/training_section.php
+++ b/dashboard_parts/training_section.php
@@ -1,3 +1,7 @@
+<?php
+require_once "includes/security.php";
+$csrf_token = generateCsrfToken();
+?>
 <div class="relative bg-gradient-to-r from-slate-900/40 to-slate-700/20 border border-gray-800 rounded-xl py-3 px-6 shadow-lg overflow-hidden mb-5">
 <div class="text-sm text-gray-300">
                 ⏳ Prochaine échéance dans : <span id="dayCountdown" class="text-purple-400 font-semibold"></span>
@@ -87,6 +91,7 @@
 
                         <!-- Champs cachés -->
                         <input type="hidden" name="training_token" value="<?= $_SESSION['training_token'] ?>">
+                        <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
                         <input type="hidden" name="failed" id="failFlag" value="0">
                     </div>
                 <?php endif; ?>

--- a/dashboard_parts/update_profile.php
+++ b/dashboard_parts/update_profile.php
@@ -1,8 +1,10 @@
 <?php
 session_start();
 require_once '../includes/config.php';
+require_once "../includes/security.php";
 
 $user_id = $_SESSION['user_id'] ?? null;
+if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) { echo json_encode(["success"=>false]); exit; }
 if (!$user_id || !isset($_POST['field'], $_POST['value'])) {
     echo json_encode(['success' => false]);
     exit;

--- a/dashboard_parts/update_rest_days.php
+++ b/dashboard_parts/update_rest_days.php
@@ -1,8 +1,10 @@
 <?php
 session_start();
 require_once '../includes/config.php';
+require_once "../includes/security.php";
 
 $user_id = $_SESSION['user_id'] ?? null;
+if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) exit;
 
 if ($user_id && isset($_POST['rest_day_1'], $_POST['rest_day_2'])) {
     $day1 = $_POST['rest_day_1'];

--- a/dashboard_parts/user_info.php
+++ b/dashboard_parts/user_info.php
@@ -1,7 +1,9 @@
 <?php
+require_once "includes/security.php";
+$csrf_token = generateCsrfToken();
 // Récup ornement prestige
 $stmt = $pdo->prepare("SELECT icon_url FROM prestige_styles WHERE code = ?");
-$stmt->execute([$user['prestige']]);
+$stmt->execute([$user["prestige"]]);
 $prestigeIcon = $stmt->fetchColumn();
 
 // Profil public
@@ -140,6 +142,7 @@ $publicUrl = $token ? $baseUrl . $token : '';
 
 <!-- Script JS -->
 <script>
+const csrfToken = "<?= $csrf_token ?>";
 function editField(field) {
     document.getElementById(field + 'Display').parentElement.style.display = 'none';
     document.getElementById(field + 'Edit').style.display = 'block';
@@ -154,7 +157,7 @@ function updateProfile(field, value) {
     fetch('dashboard_parts/update_profile.php', {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-        body: 'field=' + encodeURIComponent(field) + '&value=' + encodeURIComponent(value)
+        body: 'field=' + encodeURIComponent(field) + '&value=' + encodeURIComponent(value) + '&csrf_token=' + encodeURIComponent(csrfToken)
     })
     .then(response => response.json())
     .then(data => {
@@ -209,7 +212,7 @@ function togglePublicProfile(makePublic) {
     fetch('dashboard_parts/toggle_public.php', {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-        body: 'action=' + (makePublic ? 'public' : 'private')
+        body: 'action=' + (makePublic ? 'public' : 'private') + '&csrf_token=' + encodeURIComponent(csrfToken)
     }).then(() => window.location.reload());
 }
 function toggleAccordion(id) {

--- a/includes/security.php
+++ b/includes/security.php
@@ -1,0 +1,22 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+function generateCsrfToken() {
+    $token = bin2hex(random_bytes(32));
+    $_SESSION['csrf_token'] = $token;
+    return $token;
+}
+
+function verifyCsrfToken($token) {
+    if (!isset($_SESSION['csrf_token'])) {
+        return false;
+    }
+    $valid = hash_equals($_SESSION['csrf_token'], $token);
+    if ($valid) {
+        unset($_SESSION['csrf_token']);
+    }
+    return $valid;
+}
+?>

--- a/login.php
+++ b/login.php
@@ -1,3 +1,9 @@
+<?php
+session_start();
+require_once "includes/security.php";
+$csrf_token = generateCsrfToken();
+$error = $_GET["error"] ?? "";
+?>
 <!DOCTYPE html>
 <html lang="fr">
 <head>
@@ -22,6 +28,7 @@
 
         <form action="process_login.php" method="POST" class="space-y-4">
             <input type="text" name="identifier" required placeholder="Pseudo ou email" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600 focus:outline-none focus:ring-2 focus:ring-purple-500">
+            <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
 
             <input type="password" name="password" required placeholder="Mot de passe" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600 focus:outline-none focus:ring-2 focus:ring-purple-500">
 

--- a/process_login.php
+++ b/process_login.php
@@ -1,7 +1,9 @@
 <?php
 session_start();
 require_once 'includes/config.php';
+require_once "includes/security.php";
 
+if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) { die("Invalid CSRF token"); }
 if (!isset($_POST['identifier'], $_POST['password'])) {
     die('Champs manquants.');
 }

--- a/process_register.php
+++ b/process_register.php
@@ -1,6 +1,9 @@
 <?php
+session_start();
+require_once "includes/security.php";
 require_once 'includes/config.php';
 
+if (!verifyCsrfToken($_POST["csrf_token"] ?? "")) { die("Invalid CSRF token"); }
 // Vérifier si toutes les données sont là
 if (!isset($_POST['username'], $_POST['email'], $_POST['password'], $_POST['profile_type'])) {
     die('Formulaire incomplet.');

--- a/register.php
+++ b/register.php
@@ -1,3 +1,8 @@
+<?php
+session_start();
+require_once "includes/security.php";
+$csrf_token = generateCsrfToken();
+?>
 <!DOCTYPE html>
 <html lang="fr">
 <head>
@@ -18,6 +23,7 @@
 
         <form action="process_register.php" method="POST" class="space-y-4 text-left">
             <input type="text" name="username" required placeholder="Nom d'utilisateur" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600 focus:ring-2 focus:ring-purple-500">
+            <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
             <input type="number" name="age" required min="13" max="99" placeholder="Âge" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600 focus:ring-2 focus:ring-purple-500">
 
             <input type="email" name="email" required placeholder="Email" class="w-full px-4 py-2 rounded bg-gray-800 text-white border border-gray-600 focus:ring-2 focus:ring-purple-500">


### PR DESCRIPTION
## Summary
- add `includes/security.php` helper with `generateCsrfToken`/`verifyCsrfToken`
- insert CSRF tokens into user and admin forms
- verify tokens in processing scripts
- pass token in AJAX requests

## Testing
- `php` not available, so unable to run syntax checks